### PR TITLE
Add name mapping for Memento.

### DIFF
--- a/plots/scheme_stats_to_plot.py
+++ b/plots/scheme_stats_to_plot.py
@@ -18,7 +18,8 @@ common_schemes = {
      'puffer_ttp_20190202/bbr': ['Fugu-Feb', 'tab:orange'], 
      'puffer_ttp_20190302/bbr': ['Fugu-Mar', 'tab:olive'],
      'puffer_ttp_20190402/bbr': ['Fugu-Apr', 'tab:cyan'], 
-     'puffer_ttp_20190502/bbr': ['Fugu-May', 'tab:gray']
+     'puffer_ttp_20190502/bbr': ['Fugu-May', 'tab:gray'],
+     'fugu_variant_cl/bbr': ['Memento', '#0f6c44'],
 }
 
 # Keep name => color mapping consistent across experiments and runs.


### PR DESCRIPTION
Hi,

recently, Francis and I set up a way for my team and me to contribute our own Fugu weights to be evaluated in the Puffer experiment (relevant [google group thread](https://groups.google.com/g/puffer-stanford/c/Kz6nm7j0Zvk)) and all seems to go well there (our variant of Fugu shows up as `fugu_variant_cl/bbr` in the running eval).

We have called the retraining system we use to get our Fugu weights "Memento" (submission currently pending), and I'd like the name to show up in the plots on the website, hence this PR. 😄 

To explain the color code: I wanted to ensure that the color is the same as in the current plots, so I ran the existing code to see which color code was assigned to `"fugu_variant_cl/bbr"`:

```python
>> name="fugu_variant_cl/bbr"
>> sha = hashlib.sha256()      
>> sha.update(name.encode())
>> print('#' + sha.hexdigest()[:6])
#0f6c44
```

One final question: Is this the only location to add the name mapping, or have I missed something?